### PR TITLE
Sort-bench: Different Generators

### DIFF
--- a/sort-bench/include/dash/sortbench.h
+++ b/sort-bench/include/dash/sortbench.h
@@ -31,7 +31,8 @@ inline void parallel_rand(RandomIt begin, RandomIt end, Gen const g)
 
   for (size_t idx = 0; idx < nl; ++idx) {
     auto it = lbegin + idx;
-    *it     = g(n, idx, rng);
+    auto gidx = begin.pattern().global(idx);
+    *it     = g(n, gidx, rng);
   }
 
   begin.pattern().team().barrier();

--- a/sort-bench/include/util/Generators.h
+++ b/sort-bench/include/util/Generators.h
@@ -1,0 +1,76 @@
+#ifndef GENERATORS_H
+#define GENERATORS_H
+
+#include <random>
+#include <type_traits>
+#include <util/Random.h>
+
+namespace sortbench {
+
+template<typename key_t>
+key_t normal(size_t total, size_t index, std::mt19937& rng) {
+  using dist_t = NormalDistribution<key_t>;
+  static dist_t dist{};
+  // return index;
+  // return total - index;
+  return dist(rng) * 1E6;
+  // return static_cast<key_t>(std::round(dist(rng) * SIZE_FACTOR));
+  // return std::rand();
+}
+
+template<typename key_t>
+key_t uniform(size_t total, size_t index, std::mt19937& rng) {
+  using dist_t = UniformDistribution<key_t>;
+  static dist_t dist{};
+  // return index;
+  // return total - index;
+  return dist(rng) * 1E6;
+  // return static_cast<key_t>(std::round(dist(rng) * SIZE_FACTOR));
+  // return std::rand();
+}
+
+template<typename key_t>
+key_t sorted(size_t total, size_t index, std::mt19937& rng) {
+  return static_cast<key_t>(index);
+}
+
+template<typename key_t>
+key_t reverse(size_t total, size_t index, std::mt19937& rng) {
+  return static_cast<key_t>(total - index);
+}
+
+template<typename key_t>
+key_t partial_sorted(size_t total, size_t index, std::mt19937& rng) {
+  const double OFFS   = 0.2;
+  const double THRESH = 0.5;
+
+  if(index > total*OFFS && index < total*(OFFS+THRESH)) {
+    return static_cast<key_t>(index);
+  } else {
+    using dist_t = NormalDistribution<key_t>;
+    static dist_t dist{};
+    return dist(rng) * 1E6;
+  }
+}
+
+template<typename key_t>
+key_t partial_sorted_in_place(size_t total, size_t index, std::mt19937& rng) {
+  const double OFFS   = 0.2;
+  const double THRESH = 0.5;
+
+  using dist_t = UniformDistribution<key_t>;
+  if(index <= total*OFFS) {
+    static dist_t dist_low(0.0,total*OFFS);
+    return dist_low(rng);
+  }
+  else if(index > total*OFFS && index < total*(OFFS+THRESH)) {
+    return static_cast<key_t>(index);
+  } else {
+    static dist_t dist_high(total*(OFFS+THRESH), total);
+    return dist_high(rng);
+  }
+}
+
+}  // namespace sortbench
+
+#endif

--- a/sort-bench/sortbench.cc
+++ b/sort-bench/sortbench.cc
@@ -27,6 +27,7 @@
 
 #include <util/Logging.h>
 #include <util/Random.h>
+#include <util/Generators.h>
 #include <util/Timer.h>
 
 #define GB (1 << 30)
@@ -83,12 +84,6 @@ void Test(Container & c, size_t N, int r, size_t P,std::string const& test_case)
 
   auto const mb = N * sizeof(key_t) / MB;
 
-  using dist_t = sortbench::NormalDistribution<key_t>;
-  //using dist_t = sortbench::UniformDistribution<key_t>;
-
-  //static dist_t dist{key_t{0}, key_t{(1 << 20)}};
-  static dist_t dist{};
-
 #ifdef USE_DASH
 
   constexpr int nSamples = 250;
@@ -117,13 +112,7 @@ void Test(Container & c, size_t N, int r, size_t P,std::string const& test_case)
 
   for (size_t iter = 0; iter < NITER + BURN_IN; ++iter) {
     parallel_rand(
-        c.begin(), c.end(), [](size_t total, size_t index, std::mt19937& rng) {
-          // return index;
-          // return total - index;
-          return dist(rng) * 1E6;
-          // return static_cast<key_t>(std::round(dist(rng) * SIZE_FACTOR));
-          // return std::rand();
-        });
+        c.begin(), c.end(), sortbench::normal<key_t>);
 
 #if 0
     if (iter == 0) {


### PR DESCRIPTION
Added different generators for different distributions:
- normal (as in master)
- uniform (as in master)
- sorted
- reverse
- partial_sorted
- partial_sorted_in_place

Currently they can be switched by passing another generator to the parallel_rand function.
This could be further simplified by adding a switch to the Makefile.